### PR TITLE
Add `nodir` option to eject method to avoid error

### DIFF
--- a/guides/react.md
+++ b/guides/react.md
@@ -70,7 +70,7 @@ const glob = require('glob-all')
     // for more information about PurgeCSS.
     // Specify the path of the html files and source files
     new PurgecssPlugin({
-      paths: [paths.appHtml, ...glob.sync(`${paths.appSrc}/*`)]
+      paths: [paths.appHtml, ...glob.sync(`${paths.appSrc}/*`, { nodir: true })]
     }),
 ```
 


### PR DESCRIPTION
When building with the eject method in React, it will result in the error `EISDIR: illegal operation on a directory`.
The solution to this is to add the `nodir` option, as specified here: https://github.com/FullHuman/purgecss-webpack-plugin/issues/39